### PR TITLE
add public to protocol Storable extension

### DIFF
--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -45,7 +45,7 @@ public protocol Storable {
     func toDictionary() -> [String: AnyObject]
 }
 
-extension Storable {
+public extension Storable {
     /**
      Dictionary representation
      Returns the dictioanry representation of the current struct


### PR DESCRIPTION
After install Pantry via Cocoapods and implement init(warehouse), Xcode keep showing
`Type ‘…’ does not conform to protocol 'Storable’`

Storable extension need to be public so that `xcodeproj` can access to the extension by default