### PR TITLE
Added support for class based models with inheritance hierarchies

### DIFF
--- a/Pantry.xcodeproj/project.pbxproj
+++ b/Pantry.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3297DBA21C1CB680004EE72E /* Mirror+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3297DBA11C1CB680004EE72E /* Mirror+Serialization.swift */; };
+		3297DBA51C1CB68C004EE72E /* PantryClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3297DBA31C1CB68C004EE72E /* PantryClassTests.swift */; };
+		3297DBA61C1CB68C004EE72E /* TestClassTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3297DBA41C1CB68C004EE72E /* TestClassTypes.swift */; };
 		658AA8F31C0C6D8A00DD4834 /* PantryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658AA8F21C0C6D8A00DD4834 /* PantryTests.swift */; };
 		658AA8F51C0C6D9B00DD4834 /* Pantry.h in Headers */ = {isa = PBXBuildFile; fileRef = 658AA8F41C0C6D9B00DD4834 /* Pantry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		658AA8FD1C0C6DF900DD4834 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658AA8FB1C0C6DF900DD4834 /* AppDelegate.swift */; };
@@ -44,6 +47,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3297DBA11C1CB680004EE72E /* Mirror+Serialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Mirror+Serialization.swift"; path = "Pantry/Mirror+Serialization.swift"; sourceTree = SOURCE_ROOT; };
+		3297DBA31C1CB68C004EE72E /* PantryClassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PantryClassTests.swift; path = PantryTests/PantryClassTests.swift; sourceTree = SOURCE_ROOT; };
+		3297DBA41C1CB68C004EE72E /* TestClassTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestClassTypes.swift; path = PantryTests/TestClassTypes.swift; sourceTree = SOURCE_ROOT; };
 		658AA8F11C0C6D7E00DD4834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = PantryTests/Info.plist; sourceTree = SOURCE_ROOT; };
 		658AA8F21C0C6D8A00DD4834 /* PantryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PantryTests.swift; path = PantryTests/PantryTests.swift; sourceTree = SOURCE_ROOT; };
 		658AA8F41C0C6D9B00DD4834 /* Pantry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pantry.h; path = Pantry/Pantry.h; sourceTree = SOURCE_ROOT; };
@@ -139,6 +145,7 @@
 				658AA9081C0C7CC700DD4834 /* Storable.swift */,
 				AF5486561C160B2200E00CD0 /* Warehousable.swift */,
 				AF54865C1C162B6A00E00CD0 /* WarehouseCacheable.swift */,
+				3297DBA11C1CB680004EE72E /* Mirror+Serialization.swift */,
 			);
 			name = Pantry;
 			path = Storage;
@@ -151,6 +158,8 @@
 				AF54865F1C16360C00E00CD0 /* MemoryTests.swift */,
 				658AA8F21C0C6D8A00DD4834 /* PantryTests.swift */,
 				AF5486611C16385500E00CD0 /* TestTypes.swift */,
+				3297DBA31C1CB68C004EE72E /* PantryClassTests.swift */,
+				3297DBA41C1CB68C004EE72E /* TestClassTypes.swift */,
 			);
 			name = PantryTests;
 			path = StorageTests;
@@ -308,6 +317,7 @@
 			files = (
 				E3E39F201C19D574008989E9 /* MemoryWarehouse.swift in Sources */,
 				E3E39F211C19D574008989E9 /* JSONWarehouse.swift in Sources */,
+				3297DBA21C1CB680004EE72E /* Mirror+Serialization.swift in Sources */,
 				E3E39F221C19D574008989E9 /* Pantry.swift in Sources */,
 				E3E39F231C19D574008989E9 /* Storable.swift in Sources */,
 				E3E39F241C19D574008989E9 /* Warehousable.swift in Sources */,
@@ -319,9 +329,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3297DBA51C1CB68C004EE72E /* PantryClassTests.swift in Sources */,
 				AF5486601C16360C00E00CD0 /* MemoryTests.swift in Sources */,
 				658AA8F31C0C6D8A00DD4834 /* PantryTests.swift in Sources */,
 				AF5486621C16385500E00CD0 /* TestTypes.swift in Sources */,
+				3297DBA61C1CB68C004EE72E /* TestClassTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pantry/Mirror+Serialization.swift
+++ b/Pantry/Mirror+Serialization.swift
@@ -1,0 +1,72 @@
+//
+//  Mirror+Serialization.swift
+//  Pantry
+//
+//  Created by Ian Keen on 12/12/2015.
+//  Copyright © 2015 That Thing in Swift. All rights reserved.
+//
+
+import Foundation
+
+extension Mirror {
+    /**
+     Dictionary representation
+     Returns the dictioanry representation of the current `Mirror`
+     
+     _Adapted from [@IanKeen](https://gist.github.com/IanKeen/3a6c3b9a42aaf9fea982)_
+     - returns: [String: AnyObject]
+     */
+    func toDictionary() -> [String: AnyObject] {
+        let output = self.children.reduce([:]) { (result: [String: AnyObject], child) in
+            guard let key = child.label else { return result }
+            var actualValue = child.value
+            var childMirror = Mirror(reflecting: child.value)
+            if let style = childMirror.displayStyle where style == .Optional && childMirror.children.count > 0 {
+                // unwrap Optional type first
+                actualValue = childMirror.children.first!.value
+                childMirror = Mirror(reflecting: childMirror.children.first!.value)
+            }
+            
+            if let style = childMirror.displayStyle where style == .Collection {
+                // collections need to be unwrapped, children tested and
+                // toDictionary called on each
+                let converted: [AnyObject] = childMirror.children
+                    .filter { $0.value is Storable || $0.value is AnyObject }
+                    .map { collectionChild in
+                        if let convertable = collectionChild.value as? Storable {
+                            return convertable.toDictionary()
+                        } else {
+                            return collectionChild.value as! AnyObject
+                        }
+                }
+                return combine(result, addition: [key: converted])
+                
+            } else {
+                // non-collection types, toDictionary or just cast default types
+                if let value = actualValue as? Storable {
+                    return combine(result, addition: [key: value.toDictionary()])
+                } else if let value = actualValue as? AnyObject {
+                    return combine(result, addition: [key: value])
+                } else {
+                    // throw an error? not a type we support
+                }
+            }
+            
+            return result
+        }
+        
+        if let superClassMirror = self.superclassMirror() {
+            return combine(output, addition: superClassMirror.toDictionary())
+        }
+        return output
+    }
+    
+    // convenience for combining dictionaries
+    private func combine(from: [String: AnyObject], addition: [String: AnyObject]) -> [String: AnyObject] {
+        var result = [String: AnyObject]()
+        [from, addition].forEach { dict in
+            dict.forEach { result[$0.0] = $0.1 }
+        }
+        return result
+    }
+}

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -50,57 +50,10 @@ public extension Storable {
      Dictionary representation
      Returns the dictioanry representation of the current struct
      
-     _Adapted from [@IanKeen](https://gist.github.com/IanKeen/3a6c3b9a42aaf9fea982)_
      - returns: [String: AnyObject]
      */
     func toDictionary() -> [String: AnyObject] {
-        let mirror = Mirror(reflecting: self)
-        return mirror.children.reduce([:]) { result, child in
-            guard let key = child.label else { return result }
-            var actualValue = child.value
-            var childMirror = Mirror(reflecting: child.value)
-            if let style = childMirror.displayStyle where style == .Optional && childMirror.children.count > 0 {
-                // unwrap Optional type first
-                actualValue = childMirror.children.first!.value
-                childMirror = Mirror(reflecting: childMirror.children.first!.value)
-            }
-            
-            if let style = childMirror.displayStyle where style == .Collection {
-                // collections need to be unwrapped, children tested and
-                // toDictionary called on each
-                let converted: [AnyObject] = childMirror.children
-                    .filter { $0.value is Storable || $0.value is AnyObject }
-                    .map { collectionChild in
-                        if let convertable = collectionChild.value as? Storable {
-                            return convertable.toDictionary()
-                        } else {
-                            return collectionChild.value as! AnyObject
-                        }
-                    }
-                return combine(result, addition: [key: converted])
-                
-            } else {
-                // non-collection types, toDictionary or just cast default types
-                if let value = actualValue as? Storable {
-                    return combine(result, addition: [key: value.toDictionary()])
-                } else if let value = actualValue as? AnyObject {
-                    return combine(result, addition: [key: value])
-                } else {
-                    // throw an error? not a type we support
-                }
-            }
-            
-            return result
-        }
-    }
-    
-    // convenience for combining dictionaries
-    private func combine(from: [String: AnyObject], addition: [String: AnyObject]) -> [String: AnyObject] {
-        var result = [String: AnyObject]()
-        [from, addition].forEach { dict in
-            dict.forEach { result[$0.0] = $0.1 }
-        }
-        return result
+        return Mirror(reflecting: self).toDictionary()
     }
 }
 

--- a/PantryTests/PantryClassTests.swift
+++ b/PantryTests/PantryClassTests.swift
@@ -1,0 +1,275 @@
+//
+//  PantryClassTests.swift
+//  Pantry
+//
+//  Created by Ian Keen on 12/12/2015.
+//  Copyright © 2015 That Thing in Swift. All rights reserved.
+//
+
+import XCTest
+@testable import Pantry
+
+var classToken: dispatch_once_t = 0
+
+class PantryClassTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        dispatch_once(&classToken) {
+            let testFolder = JSONWarehouse(key: "classes").cacheFileURL().URLByDeletingLastPathComponent!
+            print("testing in",testFolder)
+            
+            // remove old files before our test
+            let urls = try? NSFileManager.defaultManager().contentsOfDirectoryAtURL(testFolder, includingPropertiesForKeys: nil, options: [.SkipsSubdirectoryDescendants, .SkipsHiddenFiles])
+            if let urls = urls {
+                for url in urls {
+                    let _ = try? NSFileManager.defaultManager().removeItemAtURL(url)
+                }
+            }
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testStorableStruct() {
+        let basic = BasicClass(name: "Nick", age: 31.5, number: 42)
+        
+        Pantry.pack(basic, key: "basic")
+        
+        if let unpackedBasic: BasicClass = Pantry.unpack("basic") {
+            XCTAssert(unpackedBasic.name == "Nick", "basic string was incorrect")
+            XCTAssert(unpackedBasic.age == 31.5, "basic float was incorrect")
+            XCTAssert(unpackedBasic.number == 42, "basic int was incorrect")
+        } else {
+            XCTFail("no basic struct could be unpacked")
+        }
+    }
+    
+    func testStorableArray() {
+        let first = BasicClass(name: "Nick", age: 31.5, number: 42)
+        let second = BasicClass(name: "Rebecca", age: 28.3, number: 87)
+        let third = BasicClass(name: "Bob", age: 60, number: 23)
+        let fourth = BasicClass(name: "Mike", age: 45.4, number: 0)
+        
+        let basics = [BasicClass](arrayLiteral: first, second, third, fourth)
+        
+        Pantry.pack(basics, key: "basic_array")
+        
+        if let unpackedBasicArray: [BasicClass] = Pantry.unpack("basic_array") {
+            XCTAssert(unpackedBasicArray.count == 4, "basic array didn't contain the right amount of structs")
+            
+            let unpackedFirst = unpackedBasicArray[0]
+            
+            XCTAssert(unpackedFirst.name == "Nick", "basic string first was incorrect")
+            XCTAssert(unpackedFirst.age == 31.5, "basic float first was incorrect")
+            XCTAssert(unpackedFirst.number == 42, "basic int first was incorrect")
+            
+            let unpackedThird = unpackedBasicArray[2]
+            
+            XCTAssert(unpackedThird.name == "Bob", "basic string third was incorrect")
+            XCTAssert(unpackedThird.age == 60, "basic float third was incorrect")
+            XCTAssert(unpackedThird.number == 23, "basic int third was incorrect")
+        } else {
+            XCTFail("no basic struct array could be unpacked")
+        }
+    }
+    
+    // nested storable types
+    func testNestedStorable() {
+        let first = BasicClass(name: "Nick", age: 31.5, number: 42)
+        
+        let nested = NestedStorableClass(name: "Top", basic: first)
+        
+        Pantry.pack(nested, key: "nested_storable")
+        
+        if let unpackedNested: NestedStorableClass = Pantry.unpack("nested_storable") {
+            XCTAssert(unpackedNested.name == "Top", "nested name was incorrect")
+            
+            if let basic = unpackedNested.basic {
+                XCTAssert(basic.name == "Nick", "nested storable name was incorrect")
+                XCTAssert(basic.age == 31.5, "nested storable age was incorrect")
+                XCTAssert(basic.number == 42, "nested storable number was incorrect")
+            } else {
+                XCTFail("nested storable doesn't exist")
+            }
+            
+        } else {
+            XCTFail("no nested storable could be unpacked")
+        }
+    }
+    
+    // nested arrays of default types
+    func testNestedArray() {
+        let nested = NestedDefaultClass(names: ["Nested","Default","Array"], numbers: [1,3,5,7,9], ages: [31.5, 42.0, 23.1])
+        
+        Pantry.pack(nested, key: "nested_default")
+        
+        if let unpackedNested: NestedDefaultClass = Pantry.unpack("nested_default") {
+            let names = unpackedNested.names
+            
+            if names.count == 3 {
+                XCTAssert(names[0] == "Nested", "nested string was incorrect")
+                XCTAssert(names[1] == "Default", "nested string was incorrect")
+                XCTAssert(names[2] == "Array", "nested string was incorrect")
+            } else {
+                XCTFail("nested string array was incorrect")
+            }
+            
+            let numbers = unpackedNested.numbers
+            
+            if numbers.count == 5 {
+                XCTAssert(numbers[0] == 1, "nested int was incorrect")
+                XCTAssert(numbers[1] == 3, "nested int was incorrect")
+                XCTAssert(numbers[2] == 5, "nested int was incorrect")
+                XCTAssert(numbers[3] == 7, "nested int was incorrect")
+                XCTAssert(numbers[4] == 9, "nested int was incorrect")
+            } else {
+                XCTFail("nested int array was incorrect")
+            }
+            
+            let ages = unpackedNested.ages
+            
+            if ages.count == 3 {
+                XCTAssert(ages[0] == 31.5, "nested float was incorrect")
+                XCTAssert(ages[1] == 42.0, "nested float was incorrect")
+                XCTAssert(ages[2] == 23.1, "nested float was incorrect")
+            } else {
+                XCTFail("nested float array was incorrect")
+            }
+        } else {
+            XCTFail("no nested defaults array could be unpacked")
+        }
+    }
+    
+    // nested arrays of storable types
+    func testNestedStorableArray() {
+        let first = BasicClass(name: "Nick", age: 31.5, number: 42)
+        let second = BasicClass(name: "Rebecca", age: 28.3, number: 87)
+        
+        let nested = NestedStorableArrayClass(name: "Nested", basics: [first, second])
+        
+        Pantry.pack(nested, key: "nested_storable_array")
+        
+        if let unpackedNested: NestedStorableArrayClass = Pantry.unpack("nested_storable_array") {
+            XCTAssert(unpackedNested.name == "Nested", "nested name was incorrect")
+            
+            XCTAssert(unpackedNested.basics.count == 2, "nested storable array count was incorrect")
+            
+            if let unpackedFirst = unpackedNested.basics.first {
+                XCTAssert(unpackedFirst.name == "Nick", "nested storable array name was incorrect")
+                XCTAssert(unpackedFirst.age == 31.5, "nested storable array age was incorrect")
+                XCTAssert(unpackedFirst.number == 42, "nested storable array number was incorrect")
+            } else {
+                XCTFail("first nested storable incorrect")
+            }
+            
+            if let unpackedSecond = unpackedNested.basics.last {
+                XCTAssert(unpackedSecond.name == "Rebecca", "nested storable array name was incorrect")
+                XCTAssert(unpackedSecond.age == 28.3, "nested storable array age was incorrect")
+                XCTAssert(unpackedSecond.number == 87, "nested storable array number was incorrect")
+            } else {
+                XCTFail("second nested storable incorrect")
+            }
+        } else {
+            XCTFail("no nested storable array could be unpacked")
+        }
+    }
+    
+    func testOptionalValueShouldCache() {
+        let optional1 = BasicOptionalClass(lastName: "Jhihguan", dogsAge: nil, leastFavoriteNumber: 1)
+        let optional2 = BasicOptionalClass(lastName: "Wane", dogsAge: 10, leastFavoriteNumber: nil)
+        let optional3 = BasicOptionalClass(lastName: nil, dogsAge: nil, leastFavoriteNumber: 1)
+        let optional4 = BasicOptionalClass(lastName: nil, dogsAge: 5, leastFavoriteNumber: nil)
+        
+        Pantry.pack(optional1, key: "optionalValueTest1")
+        Pantry.pack(optional2, key: "optionalValueTest2")
+        Pantry.pack(optional3, key: "optionalValueTest3")
+        Pantry.pack(optional4, key: "optionalValueTest4")
+        
+        if let unpackOption1: BasicOptionalClass = Pantry.unpack("optionalValueTest1") {
+            XCTAssert(unpackOption1.lastName == "Jhihguan", "unpackOption1 field lastName should have value")
+            XCTAssert(unpackOption1.dogsAge == nil, "unpackOption1 field dogsAge should be nil")
+            XCTAssert(unpackOption1.leastFavoriteNumber == 1, "unpackOption1 field leastFavoriteNumber should have value")
+        } else {
+            XCTFail("no basicoptional struct could be unpacked")
+        }
+        
+        if let unpackOption2: BasicOptionalClass = Pantry.unpack("optionalValueTest2") {
+            XCTAssert(unpackOption2.lastName == "Wane", "unpackOption2 field lastName should have value")
+            XCTAssert(unpackOption2.dogsAge == 10, "unpackOption2 field dogsAge should have value")
+            XCTAssert(unpackOption2.leastFavoriteNumber == nil, "unpackOption2 field leastFavoriteNumber should not be nil")
+        } else {
+            XCTFail("no basicoptional struct could be unpacked")
+        }
+        
+        if let unpackOption3: BasicOptionalClass = Pantry.unpack("optionalValueTest3") {
+            XCTAssert(unpackOption3.lastName == nil, "unpackOption3 field lastName should be nil")
+            XCTAssert(unpackOption3.dogsAge != 10 && unpackOption3.dogsAge == nil, "unpackOption3 field dogsAge should be nil")
+            XCTAssert(unpackOption3.leastFavoriteNumber != nil, "unpackOption3 field leastFavoriteNumber should have value")
+        } else {
+            XCTFail("no basicoptional struct could be unpacked")
+        }
+        
+        if let unpackOption4: BasicOptionalClass = Pantry.unpack("optionalValueTest4") {
+            XCTAssert(unpackOption4.lastName == nil, "unpackOption4 field lastName should be nil")
+            XCTAssert(unpackOption4.dogsAge != 10 && unpackOption4.dogsAge != nil, "unpackOption4 field dogsAge should be nil")
+            XCTAssert(unpackOption4.leastFavoriteNumber == nil, "unpackOption4 field leastFavoriteNumber should be nil")
+        } else {
+            XCTFail("no basicoptional struct could be unpacked")
+        }
+    }
+    
+    func testNestedOptionalArray() {
+        let optional1 = BasicOptionalClass(lastName: "Jhihguan", dogsAge: nil, leastFavoriteNumber: 1)
+        let optional2 = BasicOptionalClass(lastName: "Wane", dogsAge: 10, leastFavoriteNumber: nil)
+        let optional3 = BasicOptionalClass(lastName: nil, dogsAge: nil, leastFavoriteNumber: 1)
+        let nestedOptionalArray1 = NestedOptionalStorableArrayClass(name: "Wanew", optionals: [optional1, optional2, optional3])
+        let nestedOptionalArray2 = NestedOptionalStorableArrayClass(name: "Wanewww", optionals: nil)
+        
+        Pantry.pack(nestedOptionalArray1, key: "nestedOptionalArrayTest1")
+        Pantry.pack(nestedOptionalArray2, key: "nestedOptionalArrayTest2")
+        
+        if let unpackNestedOption1: NestedOptionalStorableArrayClass = Pantry.unpack("nestedOptionalArrayTest1") {
+            XCTAssert(unpackNestedOption1.name == "Wanew", "unpackNestedOption1 field name should have value")
+            if let optionals = unpackNestedOption1.optionals {
+                XCTAssert(optionals.count == 3, "unpackNestedOption1 field optionals should have 3 variables")
+                if let optionalValue1: BasicOptionalClass = optionals[0] {
+                    XCTAssert(optionalValue1.lastName == "Jhihguan", "optionalValue1 field lastName should have value")
+                    XCTAssert(optionalValue1.dogsAge == nil, "optionalValue1 field dogsAge should be nil")
+                    XCTAssert(optionalValue1.leastFavoriteNumber == 1, "optionalValue1 field leastFavoriteNumber should have value")
+                } else {
+                    XCTFail("no basicoptional struct at optionals[0]")
+                }
+                
+                if let optionalValue2: BasicOptionalClass = optionals[1] {
+                    XCTAssert(optionalValue2.lastName == "Wane", "optionalValue2 field lastName should have value")
+                    XCTAssert(optionalValue2.dogsAge == 10, "optionalValue2 field dogsAge should have value")
+                    XCTAssert(optionalValue2.leastFavoriteNumber == nil, "optionalValue2 field leastFavoriteNumber should not be nil")
+                } else {
+                    XCTFail("no basicoptional struct at optionals[1]")
+                }
+                
+                if let optionalValue3: BasicOptionalClass = optionals[2] {
+                    XCTAssert(optionalValue3.lastName == nil, "optionalValue3 field lastName should be nil")
+                    XCTAssert(optionalValue3.dogsAge != 10 && optionalValue3.dogsAge == nil, "optionalValue3 field dogsAge should be nil")
+                    XCTAssert(optionalValue3.leastFavoriteNumber != nil, "optionalValue3 field leastFavoriteNumber should have value")
+                } else {
+                    XCTFail("no basicoptional struct at optionals[2]")
+                }
+            } else {
+                XCTFail("nested optional array should have value")
+            }
+        } else {
+            XCTFail("no basicoptional nested array struct could be unpacked")
+        }
+        
+        if let unpackNestedOption2: NestedOptionalStorableArrayClass = Pantry.unpack("nestedOptionalArrayTest2") {
+            XCTAssert(unpackNestedOption2.name == "Wanewww", "unpackNestedOption2 field name should have value")
+            XCTAssert(unpackNestedOption2.optionals == nil, "unpackNestedOption2 field optionals should be nil")
+        } else {
+            XCTFail("no basicoptional nested array struct could be unpacked")
+        }
+    }
+}

--- a/PantryTests/TestClassTypes.swift
+++ b/PantryTests/TestClassTypes.swift
@@ -1,0 +1,143 @@
+//
+//  TestClassTypes.swift
+//  Pantry
+//
+//  Created by Ian Keen on 12/12/2015.
+//  Copyright © 2015 That Thing in Swift. All rights reserved.
+//
+
+import Foundation
+import Pantry
+
+class EmptyWarehouse: Warehouseable {
+    func get<T : Storable>(valueKey: String) -> [T]? {
+        return nil
+    }
+    func get<T : Storable>(valueKey: String) -> T? {
+        return nil
+    }
+    func get<T : StorableDefaultType>(valueKey: String) -> [T]? {
+        return nil
+    }
+    func get<T : StorableDefaultType>(valueKey: String) -> T? {
+        return nil
+    }
+}
+
+class ClassBase: Storable {
+    var name: String
+    
+    required init(warehouse: Warehouseable) {
+        self.name = warehouse.get("name") ?? "default"
+    }
+}
+class BasicClass: ClassBase {
+    var age: Float
+    var number: Int
+    
+    convenience init(name: String, age: Float, number: Int) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.name = name
+        self.age = age
+        self.number = number
+    }
+    required init(warehouse: Warehouseable) {
+        self.age = warehouse.get("age") ?? 20.5
+        self.number = warehouse.get("number") ?? 10
+        
+        super.init(warehouse: warehouse)
+    }
+}
+class BasicOptionalClass: Storable {
+    var lastName: String?
+    var dogsAge: Float?
+    var leastFavoriteNumber: Int?
+    
+    convenience init(lastName: String?, dogsAge: Float?, leastFavoriteNumber: Int?) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.lastName = lastName
+        self.dogsAge = dogsAge
+        self.leastFavoriteNumber = leastFavoriteNumber
+    }
+    
+    required init(warehouse: Warehouseable) {
+        self.lastName = warehouse.get("lastName")
+        self.dogsAge = warehouse.get("dogsAge")
+        self.leastFavoriteNumber = warehouse.get("leastFavoriteNumber")
+    }
+}
+
+class NestedDefaultClassBase: Storable {
+    var names: [String]
+    
+    required init(warehouse: Warehouseable) {
+        self.names = warehouse.get("names") ?? []
+    }
+}
+class NestedDefaultClass: NestedDefaultClassBase {
+    var numbers: [Int]
+    var ages: [Float]
+    
+    convenience init(names: [String], numbers: [Int], ages: [Float]) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.names = names
+        self.numbers = numbers
+        self.ages = ages
+    }
+    
+    required init(warehouse: Warehouseable) {
+        self.numbers = warehouse.get("numbers") ?? []
+        self.ages = warehouse.get("ages") ?? []
+        super.init(warehouse: warehouse)
+    }
+}
+
+class NestedStorableClass: ClassBase {
+    var basic: BasicClass?
+    
+    convenience init(name: String, basic: BasicClass?) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.name = name
+        self.basic = basic
+    }
+    
+    required init(warehouse: Warehouseable) {
+        self.basic = warehouse.get("basic")
+        super.init(warehouse: warehouse)
+    }
+}
+class NestedStorableArrayClass: ClassBase {
+    var basics: [BasicClass]
+    
+    convenience init(name: String, basics: [BasicClass]) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.name = name
+        self.basics = basics
+    }
+    
+    required init(warehouse: Warehouseable) {
+        self.basics = warehouse.get("basics") ?? []
+        super.init(warehouse: warehouse)
+    }
+}
+class NestedOptionalStorableArrayClass: Storable {
+    var name: String?
+    var optionals: [BasicOptionalClass]?
+    
+    convenience init(name: String, optionals: [BasicOptionalClass]?) {
+        self.init(warehouse: EmptyWarehouse())
+        
+        self.name = name
+        self.optionals = optionals
+    }
+    
+    required init(warehouse: Warehouseable) {
+        self.name = warehouse.get("name") ?? "default"
+        self.optionals = warehouse.get("optionals")
+    }
+}


### PR DESCRIPTION
-Moved the Mirror based serialisation to a `Mirror` extension to make it easier to traverse the inheritance chain for classes
-Duplicated the existing struct test types into class based representations with some inheritance sprinkled in
-Duplicated the relevant struct tests to also test the class models