### PR TITLE
Make storable init failable

### DIFF
--- a/Pantry/JSONWarehouse.swift
+++ b/Pantry/JSONWarehouse.swift
@@ -102,8 +102,9 @@ public class JSONWarehouse: Warehouseable, WarehouseCacheable {
                 for item in result {
                     if let item = item as? Dictionary<String, AnyObject> {
                         let warehouse = JSONWarehouse(context: item)
-                        let item = T(warehouse: warehouse)
-                        unpackedItems.append(item)
+                        if let item = T(warehouse: warehouse) {
+                            unpackedItems.append(item)
+                        }
                     }
                 }
                 return unpackedItems

--- a/Pantry/MemoryWarehouse.swift
+++ b/Pantry/MemoryWarehouse.swift
@@ -77,8 +77,9 @@ extension MemoryWarehouse: Warehouseable {
                 for item in result {
                     if let item = item as? Dictionary<String, AnyObject> {
                         let warehouse = MemoryWarehouse(context: item, inMemoryIdentifier: inMemoryIdentifier)
-                        let item = T(warehouse: warehouse)
-                        unpackedItems.append(item)
+                        if let item = T(warehouse: warehouse) {
+                            unpackedItems.append(item)
+                        }
                     }
                 }
                 return unpackedItems

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -34,7 +34,7 @@ public protocol Storable {
 
      - parameter warehouse: the `Warehouseable` object from which you can extract your struct's properties
      */
-    init(warehouse: Warehouseable)
+    init?(warehouse: Warehouseable)
 
     /**
      Dictionary representation  

--- a/PantryTests/PantryTests.swift
+++ b/PantryTests/PantryTests.swift
@@ -122,7 +122,16 @@ class PantryTests: XCTestCase {
             XCTFail("no basic struct could be unpacked")
         }
     }
-    
+
+    func testStorableFailingStruct() {
+        let failing = FailingBasic(name: "Rob", age: 28.3, number: 5)
+
+        Pantry.pack(failing, key: "failing")
+
+        let unpacked: FailingBasic? = Pantry.unpack("failing")
+        XCTAssert(unpacked == nil)
+    }
+
     func testStorableArray() {
         let first = Basic(name: "Nick", age: 31.5, number: 42)
         let second = Basic(name: "Rebecca", age: 28.3, number: 87)

--- a/PantryTests/TestTypes.swift
+++ b/PantryTests/TestTypes.swift
@@ -27,6 +27,22 @@ struct Basic: Storable {
     }
 }
 
+struct FailingBasic: Storable {
+    let name: String
+    let age: Float
+    let number: Int
+
+    init(name: String, age: Float, number: Int) {
+        self.name = name
+        self.age = age
+        self.number = number
+    }
+
+    init?(warehouse: Warehouseable) {
+        return nil
+    }
+}
+
 struct BasicOptional: Storable {
     let lastName: String?
     let dogsAge: Float?


### PR DESCRIPTION
Having the protocol use a failable init introduces possibility of
not requiring default values in your struct while still allowing for nonfailable intitializers.

This also allows for the possibility of calling a types other failable initializers from the storable initializer.