### PR TITLE
Add support for objects that conform to NSCoding

### DIFF
--- a/Pantry/JSONWarehouse.swift
+++ b/Pantry/JSONWarehouse.swift
@@ -121,6 +121,10 @@ public class JSONWarehouse: Warehouseable, WarehouseCacheable {
         try! NSFileManager.defaultManager().removeItemAtURL(cacheFileURL())
     }
     
+    static func removeAllCache() {
+        try! NSFileManager.defaultManager().removeItemAtURL(JSONWarehouse.cacheDirectory)
+    }
+    
     func loadCache() -> AnyObject? {
 
         guard context == nil else {
@@ -159,13 +163,17 @@ public class JSONWarehouse: Warehouseable, WarehouseCacheable {
         }
     }
     
-    func cacheFileURL() -> NSURL {
+    static var cacheDirectory: NSURL {
         let url = NSFileManager.defaultManager().URLsForDirectory(.CachesDirectory, inDomains: .UserDomainMask).first!
         
         let writeDirectory = url.URLByAppendingPathComponent("com.thatthinginswift.pantry")
-        let cacheLocation = writeDirectory.URLByAppendingPathComponent(self.key)
-        
-        try! NSFileManager.defaultManager().createDirectoryAtURL(writeDirectory, withIntermediateDirectories: true, attributes: nil)
+        return writeDirectory
+    }
+    
+    func cacheFileURL() -> NSURL {
+        let cacheDirectory = JSONWarehouse.cacheDirectory
+        let cacheLocation = cacheDirectory.URLByAppendingPathComponent(self.key)
+        try! NSFileManager.defaultManager().createDirectoryAtURL(cacheDirectory, withIntermediateDirectories: true, attributes: nil)
         
         return cacheLocation
     }

--- a/Pantry/JSONWarehouse.swift
+++ b/Pantry/JSONWarehouse.swift
@@ -118,7 +118,11 @@ public class JSONWarehouse: Warehouseable, WarehouseCacheable {
     }
     
     func removeCache() {
-        try! NSFileManager.defaultManager().removeItemAtURL(cacheFileURL())
+        do {
+            try NSFileManager.defaultManager().removeItemAtURL(cacheFileURL())
+        } catch {
+            print("error removing cache",error)
+        }
     }
     
     func loadCache() -> AnyObject? {

--- a/Pantry/MemoryWarehouse.swift
+++ b/Pantry/MemoryWarehouse.swift
@@ -99,6 +99,10 @@ extension MemoryWarehouse: WarehouseCacheable {
     func removeCache() {
         MemoryWarehouse.globalCache.removeValueForKey(key)
     }
+    
+    static func removeAllCache() {
+        MemoryWarehouse.globalCache = [:]
+    }
 
     func loadCache() -> AnyObject? {
 

--- a/Pantry/Mirror+Serialization.swift
+++ b/Pantry/Mirror+Serialization.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Mirror {
     /**
      Dictionary representation
-     Returns the dictioanry representation of the current `Mirror`
+     Returns the dictionary representation of the current `Mirror`
      
      _Adapted from [@IanKeen](https://gist.github.com/IanKeen/3a6c3b9a42aaf9fea982)_
      - returns: [String: AnyObject]

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -203,6 +203,15 @@ public class Pantry {
 
         warehouse.removeCache()
     }
+    
+    /// Deletes all the cache
+    ///
+    /// - Note: This will clear in-memory as well as JSON cache
+    public static func removeAllCache() {
+        ///Blindly remove all the data!
+        MemoryWarehouse.removeAllCache()
+        JSONWarehouse.removeAllCache()
+    }
 
     public static func itemExistsForKey(key: String) -> Bool {
         let warehouse = getWarehouse(key)

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -234,8 +234,8 @@ public class Pantry {
         let warehouse = getWarehouse(key)
         
         if warehouse.cacheExists() {
-            let data: NSData? = warehouse.get("NSKeyedArchiverData")
-            
+            let dataString: String? = warehouse.get("NSKeyedArchiverDataString")
+            let data = dataString.flatMap { NSData(base64EncodedString: $0, options: []) }
             return data.flatMap { NSKeyedUnarchiver.unarchiveObjectWithData($0) } as? T
         }
         

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -115,6 +115,37 @@ public class Pantry {
         warehouse.write(result, expires: .Never)
     }
 
+    /**
+     Packs a generic object that conforms to the `NSCoding` protocol
+     - parameter object: Default object that will be stored
+     - parameter key: The object's key
+     - parameter expires: The storage expiration. Defaults to `Never`
+     
+     - SeeAlso: `NSCoding`
+     */
+    public static func pack<T: NSCoding>(object: T, key: String, expires: StorageExpiry = .Never) {
+        let warehouse = getWarehouse(key)
+        
+        warehouse.write(object.toDictionary(), expires: expires)
+    }
+    
+    /**
+     Packs a collection of generic objects that conform to the `NSCoding` protocol.
+     - parameter objects: Collection of objects that will be stored
+     - parameter key: The object's key
+     
+     - SeeAlso: `NSCoding`
+     */
+    public static func pack<T: NSCoding>(objects: [T], key: String) {
+        let warehouse = getWarehouse(key)
+        
+        var result = [AnyObject]()
+        for object in objects {
+            result.append(object.toDictionary())
+        }
+        
+        warehouse.write(result, expires: .Never)
+    }
 
     // MARK: unpack generics
     
@@ -193,6 +224,24 @@ public class Pantry {
 
         return cache
     }
+    
+    /**
+     Unpacks an object that conforms to the `NSCoding` protocol
+     - parameter key: The object's key
+     - returns: T?
+     */
+    public static func unpack<T: NSCoding>(key: String) -> T? {
+        let warehouse = getWarehouse(key)
+        
+        if warehouse.cacheExists() {
+            let data: NSData? = warehouse.get("NSKeyedArchiverData")
+            
+            return data.flatMap { NSKeyedUnarchiver.unarchiveObjectWithData($0) } as? T
+        }
+        
+        return nil
+    }
+
 
     /**
      Expire a given object

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -115,6 +115,37 @@ public class Pantry {
         warehouse.write(result, expires: expires)
     }
 
+    /**
+     Packs a generic object that conforms to the `NSCoding` protocol
+     - parameter object: Default object that will be stored
+     - parameter key: The object's key
+     - parameter expires: The storage expiration. Defaults to `Never`
+     
+     - SeeAlso: `NSCoding`
+     */
+    public static func pack<T: NSCoding>(object: T, key: String, expires: StorageExpiry = .Never) {
+        let warehouse = getWarehouse(key)
+        
+        warehouse.write(object.toDictionary(), expires: expires)
+    }
+    
+    /**
+     Packs a collection of generic objects that conform to the `NSCoding` protocol.
+     - parameter objects: Collection of objects that will be stored
+     - parameter key: The object's key
+     
+     - SeeAlso: `NSCoding`
+     */
+    public static func pack<T: NSCoding>(objects: [T], key: String) {
+        let warehouse = getWarehouse(key)
+        
+        var result = [AnyObject]()
+        for object in objects {
+            result.append(object.toDictionary())
+        }
+        
+        warehouse.write(result, expires: .Never)
+    }
 
     // MARK: unpack generics
     
@@ -193,6 +224,24 @@ public class Pantry {
 
         return cache
     }
+    
+    /**
+     Unpacks an object that conforms to the `NSCoding` protocol
+     - parameter key: The object's key
+     - returns: T?
+     */
+    public static func unpack<T: NSCoding>(key: String) -> T? {
+        let warehouse = getWarehouse(key)
+        
+        if warehouse.cacheExists() {
+            let data: NSData? = warehouse.get("NSKeyedArchiverData")
+            
+            return data.flatMap { NSKeyedUnarchiver.unarchiveObjectWithData($0) } as? T
+        }
+        
+        return nil
+    }
+
 
     /**
      Expire a given object

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -54,7 +54,7 @@ public class Pantry {
      - parameter objects: Generic collection of objects that will be stored
      - parameter key: The objects' key
      */
-    public static func pack<T: Storable>(objects: [T], key: String) {
+    public static func pack<T: Storable>(objects: [T], key: String, expires: StorageExpiry = .Never) {
         let warehouse = getWarehouse(key)
         
         var result = [AnyObject]()
@@ -62,7 +62,7 @@ public class Pantry {
             result.append(object.toDictionary())
         }
 
-        warehouse.write(result, expires: .Never)
+        warehouse.write(result, expires: expires)
     }
 
     /**
@@ -86,7 +86,7 @@ public class Pantry {
 
      - SeeAlso: `StorableDefaultType`
      */
-    public static func pack<T: StorableDefaultType>(objects: [T], key: String) {
+    public static func pack<T: StorableDefaultType>(objects: [T], key: String, expires: StorageExpiry = .Never) {
         let warehouse = getWarehouse(key)
         
         var result = [AnyObject]()
@@ -94,7 +94,7 @@ public class Pantry {
             result.append(object as! AnyObject)
         }
         
-        warehouse.write(result, expires: .Never)
+        warehouse.write(result, expires: expires)
     }
 
     /**
@@ -104,7 +104,7 @@ public class Pantry {
 
      - SeeAlso: `StorableDefaultType`
      */
-    public static func pack<T: StorableDefaultType>(objects: [T?], key: String) {
+    public static func pack<T: StorableDefaultType>(objects: [T?], key: String, expires: StorageExpiry = .Never) {
         let warehouse = getWarehouse(key)
         
         var result = [AnyObject]()
@@ -112,7 +112,7 @@ public class Pantry {
             result.append(object as! AnyObject)
         }
         
-        warehouse.write(result, expires: .Never)
+        warehouse.write(result, expires: expires)
     }
 
 

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -39,7 +39,7 @@ public protocol Storable {
     /**
      Dictionary representation  
 
-     Returns the dictioanry representation of the current struct
+     Returns the dictionary representation of the current struct
      - returns: [String: AnyObject]
      */
     func toDictionary() -> [String: AnyObject]
@@ -48,7 +48,7 @@ public protocol Storable {
 public extension Storable {
     /**
      Dictionary representation
-     Returns the dictioanry representation of the current struct
+     Returns the dictionary representation of the current struct
      
      - returns: [String: AnyObject]
      */

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -101,8 +101,6 @@ extension String: StorableDefaultType { }
 extension Int: StorableDefaultType { }
 extension Float: StorableDefaultType { }
 extension Double: StorableDefaultType { }
-extension NSDate: StorableDefaultType { }
-extension NSData: StorableDefaultType { }
 
 // MARK: Enums with Raw Values
 
@@ -141,6 +139,7 @@ public extension StorableRawEnum {
 internal extension NSCoding {
     func toDictionary() -> [String: AnyObject] {
         let data = NSKeyedArchiver.archivedDataWithRootObject(self)
-        return ["NSKeyedArchiverData": data]
+        let dataString = data.base64EncodedStringWithOptions([])
+        return ["NSKeyedArchiverDataString": dataString]
     }
 }

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -91,7 +91,7 @@ public enum StorageExpiry {
 /**
 Default storable types
 
-Default types are `Bool`, `String`, `Int`, `Float`, `Double`, `NSDate`
+Default types are `Bool`, `String`, `Int`, `Float`, `Double`, `NSDate`, `NSData`
 */
 public protocol StorableDefaultType {
 }
@@ -102,6 +102,7 @@ extension Int: StorableDefaultType { }
 extension Float: StorableDefaultType { }
 extension Double: StorableDefaultType { }
 extension NSDate: StorableDefaultType { }
+extension NSData: StorableDefaultType { }
 
 // MARK: Enums with Raw Values
 

--- a/Pantry/Storable.swift
+++ b/Pantry/Storable.swift
@@ -137,3 +137,10 @@ public extension StorableRawEnum {
         }
     }
 }
+
+internal extension NSCoding {
+    func toDictionary() -> [String: AnyObject] {
+        let data = NSKeyedArchiver.archivedDataWithRootObject(self)
+        return ["NSKeyedArchiverData": data]
+    }
+}

--- a/Pantry/WarehouseCacheable.swift
+++ b/Pantry/WarehouseCacheable.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol WarehouseCacheable {
     func write(object: AnyObject, expires: StorageExpiry)
     func removeCache()
+    static func removeAllCache()
     func loadCache() -> AnyObject?
     func cacheExists() -> Bool
 }

--- a/PantryTests/MemoryTests.swift
+++ b/PantryTests/MemoryTests.swift
@@ -27,12 +27,14 @@ class MemoryTests: XCTestCase {
         let float: Float = 10.2
         let double: Double = 12.7
         let date: NSDate = NSDate(timeIntervalSince1970: 1459355217)
+        let data: NSData = NSData(base64EncodedString: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", options: [])!
 
         Pantry.pack(string, key: "ourTestString")
         Pantry.pack(int, key: "ourTestInt")
         Pantry.pack(float, key: "ourTestFloat")
         Pantry.pack(double,key: "ourTestDouble")
         Pantry.pack(date, key: "ourTestDate")
+        Pantry.pack(data, key: "ourTestData")
 
         if let unpackedString: String = Pantry.unpack("ourTestString") {
             XCTAssert(unpackedString == "Hello", "default string was incorrect")
@@ -59,7 +61,13 @@ class MemoryTests: XCTestCase {
             XCTAssert(unpackedDate.timeIntervalSince1970 == 1459355217 , "default date was incorrect")
         }
         else {
-            XCTFail("no default double could be unpacked")
+            XCTFail("no default date could be unpacked")
+        }
+        if let unpackedData: NSData = Pantry.unpack("ourTestData") {
+            XCTAssert(unpackedData.base64EncodedStringWithOptions([]) == "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "default data was incorrect")
+        }
+        else {
+            XCTFail("no default data could be unpacked")
         }
     }
 

--- a/PantryTests/PantryTests.swift
+++ b/PantryTests/PantryTests.swift
@@ -39,12 +39,15 @@ class PantryTests: XCTestCase {
         let float: Float = 10.2
         let double: Double = 20.6
         let date: NSDate = NSDate(timeIntervalSince1970: 1459355217)
+        let data: NSData = NSData(base64EncodedString: "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", options: [])!
+
 
         Pantry.pack(string, key: "ourTestString")
         Pantry.pack(int, key: "ourTestInt")
         Pantry.pack(float, key: "ourTestFloat")
         Pantry.pack(double, key: "ourTestDouble")
         Pantry.pack(date, key: "ourTestDate")
+        Pantry.pack(data, key: "ourTestData")
 
         if let unpackedString: String = Pantry.unpack("ourTestString") {
             XCTAssert(unpackedString == "Hello", "default string was incorrect")
@@ -70,7 +73,13 @@ class PantryTests: XCTestCase {
             XCTAssert(unpackedDate.timeIntervalSince1970 == 1459355217 , "default date was incorrect")
         }
         else {
-            XCTFail("no default double could be unpacked")
+            XCTFail("no default date could be unpacked")
+        }
+        if let unpackedData: NSData = Pantry.unpack("ourTestData") {
+            XCTAssert(unpackedData.base64EncodedStringWithOptions([]) == "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "default data was incorrect")
+        }
+        else {
+            XCTFail("no default data could be unpacked")
         }
     }
 


### PR DESCRIPTION
There are already a lot of objects that can be persisted using `NSCoding`. I think being able to persist them out of the box makes a lot of sense.

I had to remove `StorableDefaultType` from `NSDate` because it conforms to `NSCoding` and the compiler wouldn't know which `pack`/`unpack` to use.
