### PR TITLE
Added same error handling from removeCache() to removeAllCache()

### DIFF
--- a/Pantry/JSONWarehouse.swift
+++ b/Pantry/JSONWarehouse.swift
@@ -126,7 +126,11 @@ public class JSONWarehouse: Warehouseable, WarehouseCacheable {
     }
     
     static func removeAllCache() {
-        try! NSFileManager.defaultManager().removeItemAtURL(JSONWarehouse.cacheDirectory)
+        do {
+            try NSFileManager.defaultManager().removeItemAtURL(JSONWarehouse.cacheDirectory)
+        } catch {
+            print("error removing all cache",error)
+        }
     }
     
     func loadCache() -> AnyObject? {


### PR DESCRIPTION
In some circumstances I was experiencing a fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSCocoaErrorDomain Code=4 "“com.thatthinginswift.pantry” couldn’t be removed."