### PR TITLE
Reading the legacy storage format

### DIFF
--- a/Pantry.xcodeproj/project.pbxproj
+++ b/Pantry.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		658AA9001C0C6E0C00DD4834 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 658AA8FF1C0C6E0C00DD4834 /* Assets.xcassets */; };
 		658AA9051C0C6E1100DD4834 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 658AA9011C0C6E1100DD4834 /* LaunchScreen.storyboard */; };
 		658AA9061C0C6E1100DD4834 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 658AA9031C0C6E1100DD4834 /* Main.storyboard */; };
+		A5DD953320BEC8AB00784A82 /* StorageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DD953220BEC8AB00784A82 /* StorageType.swift */; };
 		AF3C06E51C3CAC9800234504 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3C06E31C3CAC1400234504 /* EnumTests.swift */; };
 		AF5486601C16360C00E00CD0 /* MemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF54865F1C16360C00E00CD0 /* MemoryTests.swift */; };
 		AF5486621C16385500E00CD0 /* TestTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5486611C16385500E00CD0 /* TestTypes.swift */; };
@@ -65,6 +66,7 @@
 		658AA9071C0C6E1800DD4834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = PantryExample/Info.plist; sourceTree = SOURCE_ROOT; };
 		658AA9081C0C7CC700DD4834 /* Storable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Storable.swift; path = Pantry/Storable.swift; sourceTree = SOURCE_ROOT; };
 		658AA90C1C0C823800DD4834 /* JSONWarehouse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONWarehouse.swift; path = Pantry/JSONWarehouse.swift; sourceTree = SOURCE_ROOT; };
+		A5DD953220BEC8AB00784A82 /* StorageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StorageType.swift; path = Pantry/StorageType.swift; sourceTree = SOURCE_ROOT; };
 		AF3C06E31C3CAC1400234504 /* EnumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnumTests.swift; path = PantryTests/EnumTests.swift; sourceTree = SOURCE_ROOT; };
 		AF5486561C160B2200E00CD0 /* Warehousable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Warehousable.swift; path = Pantry/Warehousable.swift; sourceTree = SOURCE_ROOT; };
 		AF5486591C16269A00E00CD0 /* MemoryWarehouse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemoryWarehouse.swift; path = Pantry/MemoryWarehouse.swift; sourceTree = SOURCE_ROOT; };
@@ -148,6 +150,7 @@
 				658AA90C1C0C823800DD4834 /* JSONWarehouse.swift */,
 				658AA8F41C0C6D9B00DD4834 /* Pantry.h */,
 				658AA8F61C0C6DA200DD4834 /* Pantry.swift */,
+				A5DD953220BEC8AB00784A82 /* StorageType.swift */,
 				658AA9081C0C7CC700DD4834 /* Storable.swift */,
 				AF5486561C160B2200E00CD0 /* Warehousable.swift */,
 				AF54865C1C162B6A00E00CD0 /* WarehouseCacheable.swift */,
@@ -326,6 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5DD953320BEC8AB00784A82 /* StorageType.swift in Sources */,
 				ECF52F611C53F3D000FBC6BA /* TestEnumTypes.swift in Sources */,
 				E3E39F201C19D574008989E9 /* MemoryWarehouse.swift in Sources */,
 				E3E39F211C19D574008989E9 /* JSONWarehouse.swift in Sources */,

--- a/Pantry.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Pantry.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Pantry/JSONWarehouse.swift
+++ b/Pantry/JSONWarehouse.swift
@@ -14,14 +14,18 @@ JSONWarehouse serializes and deserializes data
 A `JSONWarehouse` is passed in the init function of a struct that conforms to `Storable`
 */
 open class JSONWarehouse: Warehouseable, WarehouseCacheable {
+    
+    var storageType: StorageType
     var key: String
     var context: Any?
 
-    public init(key: String) {
+    public init(storageType: StorageType, key: String) {
+        self.storageType = storageType
         self.key = key
     }
 
-    public init(context: Any) {
+    public init(storageType: StorageType, context: Any) {
+        self.storageType = storageType
         self.key = ""
         self.context = context
     }
@@ -78,7 +82,7 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
                 return nil
         }
 
-        let warehouse = JSONWarehouse(context: result)
+        let warehouse = JSONWarehouse(storageType: storageType, context: result)
         return T(warehouse: warehouse)
     }
 
@@ -98,7 +102,7 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
 
         var unpackedItems = [T]()
         for case let item as [String: Any] in result {
-            let warehouse = JSONWarehouse(context: item)
+            let warehouse = JSONWarehouse(storageType: storageType, context: item)
             if let item = T(warehouse: warehouse) {
                 unpackedItems.append(item)
             }
@@ -108,7 +112,7 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
     }
 
     func write(_ object: Any, expires: StorageExpiry) {
-        let cacheLocation = cacheFileURL()
+        let cacheLocation = storageFileUrl()
         var storableDictionary: [String: Any] = [:]
         
         storableDictionary["expires"] = expires.toDate().timeIntervalSince1970
@@ -130,15 +134,15 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
     
     func removeCache() {
         do {
-            try FileManager.default.removeItem(at: cacheFileURL())
+            try FileManager.default.removeItem(at: storageFileUrl())
         } catch {
             print("error removing cache", error)
         }
     }
     
-    static func removeAllCache() {
+    static func removeAllCache(for storageType: StorageType) {
         do {
-            try FileManager.default.removeItem(at: JSONWarehouse.cacheDirectory)
+            try FileManager.default.removeItem(at: JSONWarehouse.storageDirectory(for: storageType))
         } catch {
             print("error removing all cache",error)
         }
@@ -149,7 +153,7 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
             return context
         }
 
-        let cacheLocation = cacheFileURL()
+        let cacheLocation = storageFileUrl()
 
         if let data = try? Data(contentsOf: cacheLocation),
             let metaDictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -167,8 +171,8 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
     }
     
     func cacheExists() -> Bool {
-        guard FileManager.default.fileExists(atPath: cacheFileURL().path),
-            let data = try? Data(contentsOf: cacheFileURL()),
+        guard FileManager.default.fileExists(atPath: storageFileUrl().path),
+            let data = try? Data(contentsOf: storageFileUrl()),
             let metaDictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return false
         }
@@ -186,6 +190,41 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
             removeCache()
             return false
         }
+    }
+    
+    static func storageDirectory(for storageType: StorageType) -> URL {
+        switch storageType {
+        case .volatile:     return cacheDirectory
+        case .permanent:    return applicationSupportDirectory
+        }
+    }
+    
+    private func storageFileUrl() -> URL {
+        switch storageType {
+        case .volatile:     return cacheFileURL()
+        case .permanent:    return applicationSupportFileURL()
+        }
+    }
+    
+    static var applicationSupportDirectory: URL {
+        let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        
+        let writeDirectory = url.appendingPathComponent("com.thatthinginswift.pantry")
+        return writeDirectory
+    }
+    
+    func applicationSupportFileURL() -> URL {
+        let applicationSupportDirectory = JSONWarehouse.applicationSupportDirectory
+        
+        let applicationSupportLocation = applicationSupportDirectory.appendingPathComponent(self.key)
+        
+        do {
+            try FileManager.default.createDirectory(at: applicationSupportDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            print("couldn't create directories to \(applicationSupportLocation)")
+        }
+        
+        return applicationSupportLocation
     }
     
     static var cacheDirectory: URL {

--- a/Pantry/MemoryWarehouse.swift
+++ b/Pantry/MemoryWarehouse.swift
@@ -100,7 +100,7 @@ extension MemoryWarehouse: WarehouseCacheable {
         MemoryWarehouse.globalCache.removeValue(forKey: key)
     }
     
-    static func removeAllCache() {
+    static func removeAllCache(for storageType: StorageType) {
         MemoryWarehouse.globalCache = [:]
     }
 

--- a/Pantry/Pantry.swift
+++ b/Pantry/Pantry.swift
@@ -42,9 +42,10 @@ open class Pantry {
      - parameter object: Generic object that will be stored
      - parameter key: The object's key
      - parameter expires: The storage expiration. Defaults to `Never`
+     - parameter storageType: The storage type. Defaults to `.permanent`
      */
-    open static func pack<T: Storable>(_ object: T, key: String, expires: StorageExpiry = .never) {
-        let warehouse = getWarehouse(key)
+    open static func pack<T: Storable>(_ object: T, key: String, expires: StorageExpiry = .never, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         warehouse.write(object.toDictionary() as Any, expires: expires)
     }
@@ -53,9 +54,10 @@ open class Pantry {
      Packs a generic collection of structs that conform to the `Storable` protocol
      - parameter objects: Generic collection of objects that will be stored
      - parameter key: The objects' key
+     - parameter storageType: The storage type. Defaults to `.permanent`
      */
-    open static func pack<T: Storable>(_ objects: [T], key: String, expires: StorageExpiry = .never) {
-        let warehouse = getWarehouse(key)
+    open static func pack<T: Storable>(_ objects: [T], key: String, expires: StorageExpiry = .never, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         var result = [Any]()
         for object in objects {
@@ -70,11 +72,12 @@ open class Pantry {
      - parameter object: Default object that will be stored
      - parameter key: The object's key
      - parameter expires: The storage expiration. Defaults to `Never`
+     - parameter storageType: The storage type. Defaults to `.permanent`
      
      - SeeAlso: `StorableDefaultType`
      */
-    open static func pack<T: StorableDefaultType>(_ object: T, key: String, expires: StorageExpiry = .never) {
-        let warehouse = getWarehouse(key)
+    open static func pack<T: StorableDefaultType>(_ object: T, key: String, expires: StorageExpiry = .never, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         warehouse.write(object as Any, expires: expires)
     }
@@ -83,11 +86,13 @@ open class Pantry {
      Packs a collection of default storage types.
      - parameter objects: Collection of objects that will be stored
      - parameter key: The object's key
+     - parameter expires: The storage expiration. Defaults to `Never`
+     - parameter storageType: The storage type. Defaults to `.permanent`
 
      - SeeAlso: `StorableDefaultType`
      */
-    open static func pack<T: StorableDefaultType>(_ objects: [T], key: String, expires: StorageExpiry = .never) {
-        let warehouse = getWarehouse(key)
+    open static func pack<T: StorableDefaultType>(_ objects: [T], key: String, expires: StorageExpiry = .never, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         var result = [Any]()
         for object in objects {
@@ -101,11 +106,13 @@ open class Pantry {
      Packs a collection of optional default storage types.
      - parameter objects: Collection of optional objects that will be stored
      - parameter key: The object's key
+     - parameter expires: The storage expiration. Defaults to `Never`
+     - parameter storageType: The storage type. Defaults to `.permanent`
 
      - SeeAlso: `StorableDefaultType`
      */
-    open static func pack<T: StorableDefaultType>(_ objects: [T?], key: String, expires: StorageExpiry = .never) {
-        let warehouse = getWarehouse(key)
+    open static func pack<T: StorableDefaultType>(_ objects: [T?], key: String, expires: StorageExpiry = .never, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         var result = [Any]()
         for object in objects {
@@ -121,10 +128,11 @@ open class Pantry {
     /**
     Unpacks a generic struct that conforms to the `Storable` protocol
     - parameter key: The object's key
+    - parameter storageType: The storage type. Defaults to `.permanent`
     - returns: T?
     */
-    open static func unpack<T: Storable>(_ key: String) -> T? {
-        let warehouse = getWarehouse(key)
+    open static func unpack<T: Storable>(_ key: String, storageType: StorageType = .permanent) -> T? {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         if warehouse.cacheExists() {
             return T(warehouse: warehouse)
@@ -136,10 +144,11 @@ open class Pantry {
     /**
      Unpacks a generic collection of structs that conform to the `Storable` protocol
      - parameter key: The objects' key
+     - parameter storageType: The storage type. Defaults to `.permanent`
      - returns: [T]?
      */
-    open static func unpack<T: Storable>(_ key: String) -> [T]? {
-        let warehouse = getWarehouse(key)
+    open static func unpack<T: Storable>(_ key: String, storageType: StorageType = .permanent) -> [T]? {
+        let warehouse = getWarehouse(key, storageType: storageType)
 
         guard warehouse.cacheExists(),
             let cache = warehouse.loadCache() as? Array<Any> else {
@@ -158,12 +167,13 @@ open class Pantry {
     /**
      Unpacks a collection of default storage types.
      - parameter key: The object's key
+     - parameter storageType: The storage type. Defaults to `.permanent`
      - returns: [T]?
 
      - SeeAlso: `StorableDefaultType`
      */
-    open static func unpack<T: StorableDefaultType>(_ key: String) -> [T]? {
-        let warehouse = getWarehouse(key)
+    open static func unpack<T: StorableDefaultType>(_ key: String, storageType: StorageType = .permanent) -> [T]? {
+        let warehouse = getWarehouse(key, storageType: storageType)
         
         guard warehouse.cacheExists(),
             let cache = warehouse.loadCache() as? Array<Any> else {
@@ -180,11 +190,12 @@ open class Pantry {
     /**
      Unacks a default storage type.
      - parameter key: The object's key
+     - parameter storageType: The storage type. Defaults to `.permanent`
 
      - SeeAlso: `StorableDefaultType`
      */
-    open static func unpack<T: StorableDefaultType>(_ key: String) -> T? {
-        let warehouse = getWarehouse(key)
+    open static func unpack<T: StorableDefaultType>(_ key: String, storageType: StorageType = .permanent) -> T? {
+        let warehouse = getWarehouse(key, storageType: storageType)
 
         guard warehouse.cacheExists(),
             let cache = warehouse.loadCache() as? T else {
@@ -197,46 +208,57 @@ open class Pantry {
     /**
      Expire a given object
      - parameter key: The object's key
+     - parameter storageType: The storage type. Defaults to `.permanent`
      */
-    open static func expire(_ key: String) {
-        let warehouse = getWarehouse(key)
+    open static func expire(_ key: String, storageType: StorageType = .permanent) {
+        let warehouse = getWarehouse(key, storageType: storageType)
 
         warehouse.removeCache()
     }
     
-    /// Deletes all the cache
-    ///
-    /// - Note: This will clear in-memory as well as JSON cache
-    open static func removeAllCache() {
+    /**
+     Deletes all the cache
+     - parameter storageType: The storage type. Defaults to `.permanent`
+ 
+     - Note: This will clear in-memory as well as JSON cache
+     */
+    open static func removeAllCache(for storageType: StorageType = .permanent) {
         ///Blindly remove all the data!
-        MemoryWarehouse.removeAllCache()
-        JSONWarehouse.removeAllCache()
+        MemoryWarehouse.removeAllCache(for: storageType)
+        JSONWarehouse.removeAllCache(for: storageType)
     }
 
-    open static func itemExistsForKey(_ key: String) -> Bool {
-        let warehouse = getWarehouse(key)
+    /**
+     Checks if an item exists for a given key
+     - parameter key: The object's key
+     - parameter storageType: The storage type. Defaults to `.permanent`
+     
+     - Note: This will clear in-memory as well as JSON cache
+     */
+    open static func itemExistsForKey(_ key: String, storageType: StorageType = .permanent) -> Bool {
+        let warehouse = getWarehouse(key, storageType: storageType)
         return warehouse.cacheExists()
     }
 
-    static func unpack<T: Storable>(_ dictionary: [String: Any]) -> T? {
-        let warehouse = getWarehouse(dictionary as Any)
+    static func unpack<T: Storable>(_ dictionary: [String: Any], storageType: StorageType = .permanent) -> T? {
+        let warehouse = getWarehouse(dictionary as Any, storageType: storageType)
         
         return T(warehouse: warehouse)
     }
 
-    static func getWarehouse(_ forKey: String) -> Warehouseable & WarehouseCacheable {
+    static func getWarehouse(_ forKey: String, storageType: StorageType) -> Warehouseable & WarehouseCacheable {
         if let inMemoryIdentifier = Pantry.enableInMemoryModeWithIdentifier {
             return MemoryWarehouse(key: forKey, inMemoryIdentifier: inMemoryIdentifier)
         } else {
-            return JSONWarehouse(key: forKey)
+            return JSONWarehouse(storageType: storageType, key: forKey)
         }
     }
 
-    static func getWarehouse(_ forContext: Any) -> Warehouseable {
+    static func getWarehouse(_ forContext: Any, storageType: StorageType) -> Warehouseable {
         if let inMemoryIdentifier = Pantry.enableInMemoryModeWithIdentifier {
             return MemoryWarehouse(context: forContext, inMemoryIdentifier: inMemoryIdentifier)
         } else {
-            return JSONWarehouse(context: forContext)
+            return JSONWarehouse(storageType: storageType, context: forContext)
         }
     }
 }

--- a/Pantry/StorageType.swift
+++ b/Pantry/StorageType.swift
@@ -1,0 +1,14 @@
+//
+//  StorageType.swift
+//  Pantry
+//
+//  Created by Florian Krüger on 30.05.18.
+//  Copyright © 2018 That Thing in Swift. All rights reserved.
+//
+
+import Foundation
+
+public enum StorageType {
+    case volatile
+    case permanent
+}

--- a/Pantry/WarehouseCacheable.swift
+++ b/Pantry/WarehouseCacheable.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol WarehouseCacheable {
     func write(_ object: Any, expires: StorageExpiry)
     func removeCache()
-    static func removeAllCache()
+    static func removeAllCache(for storageType: StorageType)
     func loadCache() -> Any?
     func cacheExists() -> Bool
 }


### PR DESCRIPTION
This PR enables Pantry to read its legacy storage format (plist). This is necessary when upgrading from a pre-swift-3 version of the framework a current version, otherwise the storage contents will always be tried to read as JSON (which will fail) and the `unpack` method will ultimately return `nil` although all the data was still there.

What this PR does is basically first trying to read the old format for downwards compatibility and only if that fails, read the storage contents as JSON.

You don't NEED to merge the PR if you don't want to as I can see this being a rare edge case but I wanted to offer it anyways. And I can totally see that 'reading the legacy format first' is a overhead that might be too big for the edge case it solves.

Also, I'm open for better approaches to fix this scenario if you have any. This is just a quick fix and honestly the first idea I had. But it works.